### PR TITLE
Updated readme to show correct urls.py code.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installation
 
 2. Include the loaderio URLconf in your project urls.py::
 
-    url('^$', include('loaderio.urls'))
+    url('^', include('loaderio.urls'))
 
 3. Update your database schema with the new models::
 


### PR DESCRIPTION
The regex should be just `^`. Doing `^$` means it will match only the domain and nothing else. So something like /loaderio-28016b04fdb0ed4ea066ecec5a19c1ad would 404. I'm guessing this is just a typo in the readme.
